### PR TITLE
Solana deployment with more extensions

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -7,7 +7,7 @@ resolution = false
 skip-lint = false
 
 [programs.localnet]
-oft = "Fs92vPdezafCPPGSMPbV1RXnQM6wBT9RwZJkyjDgdrT8"
+oft = "3eZMk1HzqcbgBPjjyz9Hkd2QPxLDXCiVBx2syKUYT9oC"
 
 [registry]
 url = "https://api.apr.dev"

--- a/deployments/solana-mainnet/OFT.json
+++ b/deployments/solana-mainnet/OFT.json
@@ -1,7 +1,7 @@
 {
     "programId": "Fs92vPdezafCPPGSMPbV1RXnQM6wBT9RwZJkyjDgdrT8",
-    "mint": "9Q8t1NyAyCdn9rMZhCXeohQkUvTYnkYVu8SVfK9i8zjr",
-    "mintAuthority": "2g7d1gMiRyPeTjFHDN68tmXxVSXRJVmHgmeczikTqToa",
-    "escrow": "BpheMMHDtgv73bwhu8g2Bi9aX5PMyna8GH73k4mdxEA1",
-    "oftStore": "B5VPqyXWeoRqR4kHysFUzsU78HiXtAenZuSUUrBdqQ5z"
+    "mint": "5cuPZn2xTJpXuYmGZRJ9htZ4f9YAUMXzEUnRJfmeQAtP",
+    "mintAuthority": "Hg3TKVnxhz7dSsJE21BFmsRb7xhWnQ4tEXYn2HUN1eRy",
+    "escrow": "FsficN9MDY8ScZ6C4Vz3waPzatGF3eifMHVTRosTQaHw",
+    "oftStore": "5SKfyRvm3TUij9a2kTqTQC7XH6TfiUkdLiBwF6yjE1q8"
 }

--- a/deployments/solana-mainnet/OFT.json
+++ b/deployments/solana-mainnet/OFT.json
@@ -1,7 +1,7 @@
 {
-    "programId": "Fs92vPdezafCPPGSMPbV1RXnQM6wBT9RwZJkyjDgdrT8",
-    "mint": "5cuPZn2xTJpXuYmGZRJ9htZ4f9YAUMXzEUnRJfmeQAtP",
-    "mintAuthority": "Hg3TKVnxhz7dSsJE21BFmsRb7xhWnQ4tEXYn2HUN1eRy",
-    "escrow": "FsficN9MDY8ScZ6C4Vz3waPzatGF3eifMHVTRosTQaHw",
-    "oftStore": "5SKfyRvm3TUij9a2kTqTQC7XH6TfiUkdLiBwF6yjE1q8"
+    "programId": "3eZMk1HzqcbgBPjjyz9Hkd2QPxLDXCiVBx2syKUYT9oC",
+    "mint": "FRNTPi9V3Sw9b9U8d5Q3WY7tNANT6Q394d7dYtv7Jdog",
+    "mintAuthority": "46iFgiYEY5h2uMfM9y4tDapwgqYHrx1BwQueTZDM3hnb",
+    "escrow": "E1WgsNnDwyccswm8Xhq9S4CreGSxRZtWwvYP7UvNMSfd",
+    "oftStore": "2Auo8TMjLkjmL3et9d665nmXJMXkzPEhcFas5NWoKNDr"
 }

--- a/deployments/solana-testnet/OFT.json
+++ b/deployments/solana-testnet/OFT.json
@@ -1,7 +1,7 @@
 {
     "programId": "Bo8zs7K77VmZdcFHZiKXLii49U9SFUSaNv6SgbzTsiMd",
-    "mint": "3TFinhpQ6Y2jAMGZrPhQvD2YCt9DWykdftiMwsYuqKtA",
-    "mintAuthority": "8tAQdND777HLMBuE3NiEXQL7YWxHFTwT5uv7n1WBfDcT",
-    "escrow": "2A8B8RjZUzsUi4DoLT5nJcipaBbRbwkE8BYWovXXLhGc",
-    "oftStore": "4obLvwMYcX5EvWB5mEhuXig6C7D6UaN96GsnMzYSfJEP"
+    "mint": "FHYdL2jU5CN7PKQrtf3YBqRNfMWdtKuJfzegw3PN5Sk4",
+    "mintAuthority": "D77KvEAA6H5cLzQjihebiq766konDyfekQLDZhKq6HHy",
+    "escrow": "H1zcsVbmfYYgNQZ6vRcdvs42QWp8vK9myKZQPuSt2nFZ",
+    "oftStore": "7YU5Dnpb4x7qAKViAroQSoLnq2SWfwpri3M7zUfjbJZB"
 }

--- a/deployments/solana-testnet/OFT.json
+++ b/deployments/solana-testnet/OFT.json
@@ -1,7 +1,7 @@
 {
     "programId": "Bo8zs7K77VmZdcFHZiKXLii49U9SFUSaNv6SgbzTsiMd",
-    "mint": "t84qy9LF7LwN14LV5vn8KKFYvULiUeCjF4JLbzUAexh",
-    "mintAuthority": "3fMGk1tPfAN1yv7wMnNBfGxefo5SS6f5s1uWWYmWY2Np",
-    "escrow": "FMUPhkPZ5RReGZJfxaz7uL3skoAnMK2t3RBxJeA4AA8X",
-    "oftStore": "GMcBuqGdcsPmV1Ax3ttZ8mmZUrkCifrZZFVQGV9USs5L"
+    "mint": "3TFinhpQ6Y2jAMGZrPhQvD2YCt9DWykdftiMwsYuqKtA",
+    "mintAuthority": "8tAQdND777HLMBuE3NiEXQL7YWxHFTwT5uv7n1WBfDcT",
+    "escrow": "2A8B8RjZUzsUi4DoLT5nJcipaBbRbwkE8BYWovXXLhGc",
+    "oftStore": "4obLvwMYcX5EvWB5mEhuXig6C7D6UaN96GsnMzYSfJEP"
 }


### PR DESCRIPTION
## In this PR:
- Deployed [Solana token2022](https://explorer.solana.com/address/FRNTPi9V3Sw9b9U8d5Q3WY7tNANT6Q394d7dYtv7Jdog) with the following extensions on mainnet / testnet

<img width="1136" height="777" alt="Screenshot 2025-08-18 at 5 44 53 PM" src="https://github.com/user-attachments/assets/e3694757-639d-4553-8cf9-fa89c0efadf9" />

- Initialized OFT with new token
- Updated debug task to list the permanent delegate